### PR TITLE
Update Buefy to 0.9.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "misato-frontend",
       "license": "MIT",
       "dependencies": {
-        "buefy": "^0.9.8",
+        "buefy": "^0.9.11",
         "bulma": "^0.9.0",
         "emojis-list": "^3.0.0",
         "twemoji": "^13.1.0",
@@ -2383,9 +2384,9 @@
       }
     },
     "node_modules/buefy": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.8.tgz",
-      "integrity": "sha512-VBGAD6WtmgpPdiRnBXaTleS3ifpNu9rbInAr54YL8KJw1RhCb8JtGYYYVRjllnDQmN0jQjC5lYoPR9KpfTe+Cw==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.11.tgz",
+      "integrity": "sha512-WP32SiaM9WVxDtzgdiq7V2zyIvn41NboPgluVqdB6OAi1/QhjO/63m6hd/jy6Vk8r+zuhIZD+aP9KlQ10EhxTQ==",
       "dependencies": {
         "bulma": "0.9.3"
       },
@@ -11431,9 +11432,9 @@
       }
     },
     "buefy": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.8.tgz",
-      "integrity": "sha512-VBGAD6WtmgpPdiRnBXaTleS3ifpNu9rbInAr54YL8KJw1RhCb8JtGYYYVRjllnDQmN0jQjC5lYoPR9KpfTe+Cw==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.11.tgz",
+      "integrity": "sha512-WP32SiaM9WVxDtzgdiq7V2zyIvn41NboPgluVqdB6OAi1/QhjO/63m6hd/jy6Vk8r+zuhIZD+aP9KlQ10EhxTQ==",
       "requires": {
         "bulma": "0.9.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "buefy": "^0.8.20",
+        "buefy": "^0.9.8",
         "bulma": "^0.9.0",
         "emojis-list": "^3.0.0",
         "twemoji": "^13.1.0",
@@ -2383,24 +2383,19 @@
       }
     },
     "node_modules/buefy": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.8.20.tgz",
-      "integrity": "sha512-pg8Cn0m9cjqp2/vaKT4VIfU8KIumuX/gAT1GtearXRs56+kKqAPx3j9O8cm9W6P4jPUCHajKX6H8AqD0ram2Bg==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.8.tgz",
+      "integrity": "sha512-VBGAD6WtmgpPdiRnBXaTleS3ifpNu9rbInAr54YL8KJw1RhCb8JtGYYYVRjllnDQmN0jQjC5lYoPR9KpfTe+Cw==",
       "dependencies": {
-        "bulma": "0.7.5"
+        "bulma": "0.9.3"
       },
       "engines": {
         "node": ">= 4.0.0",
         "npm": ">= 3.0.0"
       },
       "peerDependencies": {
-        "vue": "^2.5.18"
+        "vue": "^2.6.11"
       }
-    },
-    "node_modules/buefy/node_modules/bulma": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.5.tgz",
-      "integrity": "sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -11436,18 +11431,11 @@
       }
     },
     "buefy": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.8.20.tgz",
-      "integrity": "sha512-pg8Cn0m9cjqp2/vaKT4VIfU8KIumuX/gAT1GtearXRs56+kKqAPx3j9O8cm9W6P4jPUCHajKX6H8AqD0ram2Bg==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/buefy/-/buefy-0.9.8.tgz",
+      "integrity": "sha512-VBGAD6WtmgpPdiRnBXaTleS3ifpNu9rbInAr54YL8KJw1RhCb8JtGYYYVRjllnDQmN0jQjC5lYoPR9KpfTe+Cw==",
       "requires": {
-        "bulma": "0.7.5"
-      },
-      "dependencies": {
-        "bulma": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.7.5.tgz",
-          "integrity": "sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw=="
-        }
+        "bulma": "0.9.3"
       }
     },
     "buffer-from": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "webpack serve --open"
   },
   "dependencies": {
-    "buefy": "^0.8.20",
+    "buefy": "^0.9.8",
     "bulma": "^0.9.0",
     "emojis-list": "^3.0.0",
     "twemoji": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "webpack serve --open"
   },
   "dependencies": {
-    "buefy": "^0.9.8",
+    "buefy": "^0.9.11",
     "bulma": "^0.9.0",
     "emojis-list": "^3.0.0",
     "twemoji": "^13.1.0",


### PR DESCRIPTION
Fixes #4. This is a Buefy issue - upgrading to 0.9.8 fixes most of the issues, and the breaking changes between 0.8 and 0.9 appear to be things we don't need to worry about. There's still one left-over warning that will be fixed with the next release that includes https://github.com/buefy/buefy/commit/c0339de5d9804feee772de2b409ed871e31a8581.